### PR TITLE
Embed fonts in training curve plots

### DIFF
--- a/examples/addition-example/plot_training_curves.py
+++ b/examples/addition-example/plot_training_curves.py
@@ -5,6 +5,9 @@ import argparse
 import matplotlib.pyplot as plt
 import pandas as pd
 
+# Embed fonts in the output file
+plt.rcParams['pdf.fonttype'] = 42
+
 parser = argparse.ArgumentParser(description="Visualize training curves of addition example runs.")
 parser.add_argument(
     "-r", "--resultFile", default="./results/result.json", help="The relative path of the file result.json"

--- a/examples/handover/plot_training_curves.py
+++ b/examples/handover/plot_training_curves.py
@@ -5,6 +5,8 @@ import argparse
 import matplotlib.pyplot as plt
 import pandas as pd
 
+# Embed fonts in the output file
+plt.rcParams['pdf.fonttype'] = 42
 
 def plot_reward(progress_dir: str, subdir: str, label: str, plotted_iterations: int) -> None:
     progress_file = f"{progress_dir}/{subdir}/result.json"


### PR DESCRIPTION
Change the fonts in the training curve plots of the a+b and the handover example to embedded fonts.